### PR TITLE
tgvejs as scoped package

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,17 @@ spatial data.
 
 ## npm package
 
+> note: the older versions released under https://www.npmjs.com/package/eatlas will be deprecated.
+
 This is a React Component ES Module that can be embedded in your React applications. For an example how to import the TGVE package using `npm`, see the [`tgve/app`](https://github.com/tgve/app) repo. Following is a snippet of ReactJS from that repo:
 
 ``` javascript
 import React from 'react';
-import Eatlas from 'eatlas';
+import Tgve from '@tgve/tgvejs';
 
 function App() {
   return (
-    <Eatlas defaultURL={process.env.REACT_APP_DEFAULT_URL}/>
+    <Tgve defaultURL={process.env.REACT_APP_DEFAULT_URL}/>
   );
 }
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eatlas",
-  "version": "1.3.5-beta.0",
+  "version": "1.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "eatlas",
-      "version": "1.3.5-beta.0",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "@turf/bbox": "^6.3.0",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "eatlas",
+  "name": "@tgve/tgvejs",
   "description": "Turing Geovisualization Engine (TGVE) front-end npm package.",
   "version": "1.3.5-beta.0",
   "main": "dist/index.js",
-  "author": "L Hama (https://github.com/layik)",
+  "author": "TGVE (https://github.com/tgve)",
   "contributors": [
     "Dr. R Beecham",
     "Dr. N Lomax"
@@ -11,7 +11,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/layik/eatlas.git#npm"
+    "url": "https://github.com/tgve/tgvejs.git"
   },
   "files": [
     "README.md",
@@ -32,7 +32,6 @@
     "html2canvas": "^1.3.2",
     "luxon": "^1.25.0",
     "marked": "^4.0.10",
-    "plotly.js": "^1.58.4",
     "prop-types": "^15.6.2",
     "react-bootstrap": "^0.32.4",
     "react-leaflet": "^2.8.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tgve/tgvejs",
   "description": "Turing Geovisualization Engine (TGVE) front-end npm package.",
-  "version": "1.3.5-beta.0",
+  "version": "1.4.0",
   "main": "dist/index.js",
   "author": "Layik Hama (https://github.com/layik)",
   "contributors": [


### PR DESCRIPTION
We find the free organisation compared to paid personal accounts the way forward. Therefore, we agreed on a `scoped` release from this version onwards. Although we strongly wanted to keep `tgvejs` and not a fan of `@tgve/tgvejs` package name.