### PR TITLE
Feature/unify colours

### DIFF
--- a/src/home/util.js
+++ b/src/home/util.js
@@ -160,8 +160,8 @@ const generateLayer = (values = {}, props, state, renderTooltip) => {
   }
 
   if (layerName === 'arc') {
-    options.getSourceColor = getColorArray(cn || colorName);
-    options.getTargetColor = getColorArray(cn || colorName);
+    options.getSourceColor = colorScale(getMin(domain), domain, 180, cn || state.colorName);
+    options.getTargetColor = colorScale(getMax(domain), domain, 180, cn || state.colorName);
   }
 
   let newLegend = state.legend;

--- a/src/home/util.js
+++ b/src/home/util.js
@@ -158,6 +158,12 @@ const generateLayer = (values = {}, props, state, renderTooltip) => {
       }
     }
   }
+
+  if (layerName === 'arc') {
+    options.getSourceColor = getColorArray(cn || colorName);
+    options.getTargetColor = getColorArray(cn || colorName);
+  }
+
   let newLegend = state.legend;
 
   const getValue = (d) => {


### PR DESCRIPTION
Partial fix to #84: 
* Add an "if" block in `src/home/util.js` to make the "arc" layer use the colour range given by the ColourPicker.   
* Start and end of each arc will be the extremes of the chosen colour range.